### PR TITLE
Added support for custom scrolling context

### DIFF
--- a/src/scrolltobyspeed.jquery.js
+++ b/src/scrolltobyspeed.jquery.js
@@ -2,8 +2,6 @@
   $.fn.scrollToBySpeed = function (args) {
     var defaults
       , settings
-      , $d = $('html,body')
-      , $w = $(window)
       , distance
       , duration
       ;
@@ -13,15 +11,19 @@
     , offset: 0
     , mode: 'chain'
     , easing: 'swing'
+    , context: $('html,body')
     };
  
     settings = $.extend(defaults,args);
- 
-    distance = Math.abs( $w.scrollTop() - $(this).offset().top );
+    $c = settings.context;
+
+	 targetPos = Math.abs( $c.scrollTop() + $(this).offset().top );
+	 
+    distance = Math.abs( $c.scrollTop() - targetPos );
     duration = ( distance / settings.speed ) * 1000;
 
-    $d.animate({
-      scrollTop: $(this).offset().top - settings.offset
+    $c.animate({
+      scrollTop: targetPos - settings.offset
     }, duration, settings.easing);
  
     if ( settings.mode !== 'chain' ) {


### PR DESCRIPTION
This change makes it possible to use scrollToBySpeed for elements with scrollable content (e.g., overflow: auto), instead of only on the whole window. It's working great in my particular use case (fixed position full screen divs that we switch between using off canvas layout techniques), but I haven't tested this outside of that, and I have not tested this with the default (html,body) usage. It might still need a little bit of tweaking, but I think this is a useful feature so I thought it was worth sharing the code.
