### PR TITLE
Fixed scrolling position problems

### DIFF
--- a/src/scrolltobyspeed.jquery.js
+++ b/src/scrolltobyspeed.jquery.js
@@ -29,7 +29,7 @@
       $w = $(settings.context);
     }
 
-    targetPos = Math.abs( $d.scrollTop() + $(this).offset().top - $d.offset().top );
+    targetPos = $(this).offset().top;
 
     distance = Math.abs( $w.scrollTop() - targetPos );
     duration = ( distance / settings.speed ) * 1000;


### PR DESCRIPTION
Only in Chrome the ScrollTo position was calculated correctly, now it works in Firefox, Chrome, Safari, IE
