### PR TITLE
Alternate calculations depending on context

### DIFF
--- a/src/scrolltobyspeed.jquery.js
+++ b/src/scrolltobyspeed.jquery.js
@@ -29,7 +29,8 @@
       $w = $(settings.context);
     }
 
-    targetPos = Math.abs( $d.scrollTop() + $(this).offset().top - $d.offset().top );
+    if ( settings.context == '__window' ) targetPos = $(this).offset().top;
+    else targetPos = $d.scrollTop() + $(this).offset().top - $d.offset().top;
 
     distance = Math.abs( $w.scrollTop() - targetPos );
     duration = ( distance / settings.speed ) * 1000;


### PR DESCRIPTION
This seems to be a viable workaround for the [Issues in Firefox](https://github.com/ryanburnette/scrollToBySpeed/issues/6).
